### PR TITLE
feat: #8 codeタグを装飾

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react-transition-group": "^4.4.6",
         "eslint": "8.56.0",
         "eslint-config-next": "14.1.0",
+        "highlight.js": "^11.9.0",
         "html-react-parser": "^4.2.2",
         "microcms-js-sdk": "^2.7.0",
         "next": "^14.1.0",
@@ -12094,6 +12095,14 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
+      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hmac-drbg": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/react-transition-group": "^4.4.6",
     "eslint": "8.56.0",
     "eslint-config-next": "14.1.0",
+    "highlight.js": "^11.9.0",
     "html-react-parser": "^4.2.2",
     "microcms-js-sdk": "^2.7.0",
     "next": "^14.1.0",

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,26 @@
+import { Sheet, Typography } from "@mui/joy";
+import { ReactNode } from "react";
+
+export default function CodeBlock({ children }: { children: ReactNode }) {
+  return (
+    <Sheet
+      component="pre"
+      color="neutral"
+      variant="soft"
+      sx={{
+        p: 1,
+        border: 1,
+        borderColor: "lightgray",
+        borderRadius: 4,
+        borderStyle: "dotted",
+        whiteSpace: "pre",
+        overflowX: "scroll",
+        scrollbarWidth: "thin",
+      }}
+    >
+      <Typography component="code" level="body-xs">
+        {children}
+      </Typography>
+    </Sheet>
+  );
+}

--- a/src/components/CodeSpan.tsx
+++ b/src/components/CodeSpan.tsx
@@ -1,0 +1,21 @@
+import { Typography } from "@mui/joy";
+import { ReactNode } from "react";
+
+export default function CodeSpan({ children }: { children: ReactNode }) {
+  return (
+    <Typography
+      component="code"
+      level="body-xs"
+      color="neutral"
+      variant="soft"
+      display="inline-block"
+      border={1}
+      borderColor="lightgray"
+      borderRadius={4}
+      sx={{ borderStyle: "dotted" }}
+      m={0.25}
+    >
+      {children}
+    </Typography>
+  );
+}

--- a/src/libs/html-parser-option.tsx
+++ b/src/libs/html-parser-option.tsx
@@ -1,15 +1,74 @@
+import CodeBlock from "@/components/CodeBlock";
+import CodeSpan from "@/components/CodeSpan";
 import ImageWithModal from "@/components/ImageWithModal";
-import { Element, HTMLReactParserOptions } from "html-react-parser";
+import { ElementType } from "domelementtype";
+import { ChildNode } from "domhandler";
+import hljs from "highlight.js";
+import "highlight.js/styles/atom-one-dark.css";
+import parse, {
+  DOMNode,
+  domToReact,
+  Element,
+  HTMLReactParserOptions,
+  Text,
+} from "html-react-parser";
 
 export const htmlParserOptions: HTMLReactParserOptions = {
   replace: (domNode) => {
-    if (domNode instanceof Element && domNode.type === "tag") {
-      if (domNode.name === "img") {
-        // TODO: ひとつ上の <figure /> にonClickをつけるようにしたい
-        const src = domNode.attribs["src"];
-        const alt = domNode.attribs["alt"];
-        return <ImageWithModal src={src} alt={alt} />;
+    const tagElement = getTagElement(domNode);
+    if (!tagElement) {
+      return;
+    }
+
+    if (tagElement.name === "img") {
+      // TODO: ひとつ上の <figure /> にonClickをつけるようにしたい
+      const src = tagElement.attribs["src"];
+      const alt = tagElement.attribs["alt"];
+      return <ImageWithModal src={src} alt={alt} />;
+    } else if (tagElement.name === "code") {
+      return <CodeSpan>{domToReact(tagElement.children)}</CodeSpan>;
+    } else if (tagElement.name === "pre") {
+      const childTagElement = tagElement.childNodes
+        .map((c) => getTagElement(c))
+        .find((c) => c);
+      if (!childTagElement) {
+        return;
+      }
+
+      if (childTagElement.name === "code") {
+        const className = childTagElement.attribs["class"];
+        // https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md
+        const language =
+          className && className.includes("language-")
+            ? className.split("-")[1]
+            : "plaintext";
+        return (
+          <CodeBlock>
+            {parse(
+              parseNodeToHighlightTextDOM(childTagElement.firstChild, language),
+            )}
+          </CodeBlock>
+        );
       }
     }
   },
 };
+
+function getTagElement(node: DOMNode | ChildNode) {
+  return node instanceof Element && node.type == ElementType.Tag
+    ? (node as Element)
+    : undefined;
+}
+
+function parseNodeToHighlightTextDOM(
+  node: DOMNode | ChildNode | null,
+  language: string,
+) {
+  if (node instanceof Text) {
+    return hljs.highlight(node.data, {
+      language: language,
+      ignoreIllegals: true,
+    }).value;
+  }
+  return "";
+}


### PR DESCRIPTION
### after
![image](https://github.com/null256code/timesblog/assets/19668528/2141b899-f989-4fd3-aeb9-036c50f81423)

### before
![image](https://github.com/null256code/timesblog/assets/19668528/ccd9e588-6b2f-47c2-aee0-0a3821122adf)
